### PR TITLE
Fix Linux support

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -135,7 +135,7 @@ async function vlc() {
 
 	const address = `http://${ip}`
 
-	const instance = execa(vlcStatic(), ["--extraintf", "http", "--intf", "wx", "--http-host", ip, "--http-port", port.toString(), "--http-password", password])
+	const instance = execa(vlcStatic(), ["--extraintf", "http", "--intf", "dummy", "--http-host", ip, "--http-port", port.toString(), "--http-password", password])
 
 	return new class VLC {
 		/**


### PR DESCRIPTION
@Richienb,

I wanted to use your [Audic](https://github.com/Richienb/audic) package and it was not working for me. I saw an [open issue](https://github.com/Richienb/audic/issues/7) there describing the exact same issue I was having and figured out what is the problem: our VLC installation (Arch Linux) does not have the `wx` interface option. Since there is no need for a graphical interface, this PR changes it to `dummy` - which means no graphical interface.

Well, see if it makes sense for you.